### PR TITLE
Extract Cache-Control headers from subrequest and determine the minimum

### DIFF
--- a/src/rib_callback.erl
+++ b/src/rib_callback.erl
@@ -43,8 +43,17 @@ handle('OPTIONS',[<<"v1">>, <<"batch">>], _Req) ->
 handle('POST',[<<"v1">>, <<"batch">>], Req) ->
     Requests = jiffy:decode(elli_request:body(Req), [return_maps]),
     {Taken, {ok, Responses}} = timer:tc(rib_fetch, fetch_all, [Requests]),
+    CacheHeaders = lists:map(fun(R) ->
+      {AllHeaders} = maps:get(headers, maps:get(response, R)),
+      case proplists:get_value(<<"cache-control">>, AllHeaders, undefined) of
+          undefined -> undefined;
+          Rest -> rib_parse:parse_cache_control(binary_to_list(Rest))
+      end
+    end, Responses),
+    Minimal = rib_parse:minimal_cache(CacheHeaders),
+    Cache = rib_parse:format_cache_control(Minimal),
     Data = #{results => Responses, time_taken => Taken / 1000},
-    encode_response(Req, Data);
+    encode_response(Req, Cache, Data);
 
 handle(_, _, _Req) ->
     {404, [], <<"Not Found">>}.
@@ -63,9 +72,10 @@ error_response(Err) ->
      [{<<"Content-type">>, <<"text/plain; charset=utf-8">>}],
      io_lib:format("~p~n", [Err])}.
 
-encode_response(Req, Data) ->
+encode_response(Req, Cache, Data) ->
     JSON = jiffy:encode(Data),
-    Headers = [{<<"Content-Type">>, <<"application/json; charset=utf-8">>}],
+    Headers = [{<<"Content-Type">>, <<"application/json; charset=utf-8">>},
+               {<<"Cache-Control">>, list_to_binary(Cache)}],
     case accepted_encoding(Req) of
         none -> {200, Headers, JSON};
         gzip -> {200,

--- a/src/rib_callback.erl
+++ b/src/rib_callback.erl
@@ -74,8 +74,11 @@ error_response(Err) ->
 
 encode_response(Req, Cache, Data) ->
     JSON = jiffy:encode(Data),
-    Headers = [{<<"Content-Type">>, <<"application/json; charset=utf-8">>},
-               {<<"Cache-Control">>, list_to_binary(Cache)}],
+    Headers = [{<<"Content-Type">>, <<"application/json; charset=utf-8">>}|
+               case Cache of
+                 undefined -> [];
+                 _ -> [{<<"Cache-Control">>, list_to_binary(Cache)}]
+               end],
     case accepted_encoding(Req) of
         none -> {200, Headers, JSON};
         gzip -> {200,

--- a/src/rib_parse.erl
+++ b/src/rib_parse.erl
@@ -29,15 +29,19 @@ format_cache_control(Value) ->
 
 minimal_cache(Headers) ->
     lists:foldl(fun(Elem, AccIn) ->
-        PrivateNew = proplists:get_value(private, Elem, false),
-        PrivateOld = proplists:get_value(private, AccIn, false),
-        MaxAgeNew = proplists:get_value('max-age', Elem, "3600"),
-        MaxAgeOld = proplists:get_value('max-age', AccIn, "3600"),
-        MaxAge = minimal_max_age(MaxAgeOld, MaxAgeNew),
-        if
-          (not PrivateNew) and (not PrivateOld) -> [{public, true}, {'max-age', MaxAge}];
-          true -> [{private, true}, {'max-age', MaxAge}]
-        end
+        case Elem of
+          undefined -> undefined;
+          Elem ->
+            PrivateNew = proplists:get_value(private, Elem, false),
+            PrivateOld = proplists:get_value(private, AccIn, false),
+            MaxAgeNew = proplists:get_value('max-age', Elem, "3600"),
+            MaxAgeOld = proplists:get_value('max-age', AccIn, "3600"),
+            MaxAge = minimal_max_age(MaxAgeOld, MaxAgeNew),
+            case {PrivateNew, PrivateOld} of
+              {false, false} ->  [{public, true}, {'max-age', MaxAge}];
+              _ -> [{private, true}, {'max-age', MaxAge}]
+            end
+         end
       end,
       [{public, true},
        {'max-age', "3600"}],

--- a/src/rib_parse.erl
+++ b/src/rib_parse.erl
@@ -1,5 +1,5 @@
 -module(rib_parse).
--export([parse_uri/1]).
+-export([parse_uri/1, parse_cache_control/1, minimal_cache/1, format_cache_control/1]).
 
 %% API
 
@@ -8,6 +8,45 @@ parse_uri(Uri) ->
         nomatch          -> split_uri(Uri, []);
         {match, Matches} -> split_uri(Uri, Matches)
     end.
+
+parse_cache_control(Value) ->
+    {ok, R} = re:compile("(\".*?\"|[^\",\\s]+)(?=\\s*,|\\s*$)"),
+    {match, Matches} = re:run(Value, R, [{capture,[1],list},global]),
+    lists:map(fun([S]) ->
+      V = re:split(S, "=", [{return,list}]),
+      elem_to_prop(V)
+    end, Matches).
+
+format_cache_control(Value) ->
+    Private = proplists:get_value(private, Value, false),
+    Public = proplists:get_value(public, Value, false),
+    MaxAge = proplists:get_value('max-age', Value),
+    Privacy = case {Public, Private} of
+      {_, true} -> "private";
+      _ -> "public"
+    end,
+    lists:concat([Privacy, ", max-age=", MaxAge]).
+
+minimal_cache(Headers) ->
+    lists:foldl(fun(Elem, AccIn) ->
+        PrivateNew = proplists:get_value(private, Elem, false),
+        PrivateOld = proplists:get_value(private, AccIn, false),
+        MaxAgeNew = proplists:get_value('max-age', Elem, "3600"),
+        MaxAgeOld = proplists:get_value('max-age', AccIn, "3600"),
+        MaxAge = minimal_max_age(MaxAgeOld, MaxAgeNew),
+        if
+          (not PrivateNew) and (not PrivateOld) -> [{public, true}, {'max-age', MaxAge}];
+          true -> [{private, true}, {'max-age', MaxAge}]
+        end
+      end,
+      [{public, true},
+       {'max-age', "3600"}],
+      Headers).
+
+minimal_max_age(Age1, Age2) ->
+    {A1, []} = string:to_integer(Age1),
+    {A2, []} = string:to_integer(Age2),
+    integer_to_list(min(A1, A2)).
 
 %% Implementation
 
@@ -29,3 +68,6 @@ split_uri(Uri, [], Offset, Chunks) ->
         0   -> Chunks;
         Rem -> Chunks ++ [{binary, binary:part(Uri, Size, -Rem)}]
     end.
+
+elem_to_prop([Key]) -> {list_to_atom(Key), true};
+elem_to_prop([Key|[Value]]) -> {list_to_atom(Key), Value}.


### PR DESCRIPTION
This makes sure that the Cache header returned by Rib is not longer than the shortest duration of the requests.

First time I wrote Erlang, so it is probably a horrible eye-sore. Also it might not handle the case of no cache headers being present in the subrequests. It's more like an proof of concept.
