### PR TITLE
Add health-check endpoint

### DIFF
--- a/src/rib_callback.erl
+++ b/src/rib_callback.erl
@@ -41,6 +41,9 @@ auth_fun(Req, User, Password) ->
 
 %% Implementation
 
+handle('GET',[<<"health-check">>], _Req) ->
+    {200, [], <<"Ok\n">>};
+
 handle('GET',[<<"metrics">>], _Req) ->
     {200, [], rib_metrics:report()};
 

--- a/test/rib_tests.erl
+++ b/test/rib_tests.erl
@@ -47,6 +47,7 @@ integration_test_() ->
     [{setup, fun setup/0, fun teardown/1, fun test/0},
      {setup, fun setup/0, fun teardown/1, fun test_metrics_auth_401/0},
      {setup, fun setup/0, fun teardown/1, fun test_metrics_auth_200/0},
+     {setup, fun setup/0, fun teardown/1, fun test_health_check_200/0},
      {setup, fun setup/0, fun teardown/1, fun test_gzip_response/0},
      {setup, fun setup/0, fun teardown/1, fun test_options_cors_without_origin/0},
      {setup, fun setup/0, fun teardown/1, fun test_options_cors_with_origin/0},
@@ -148,6 +149,12 @@ test_metrics_auth_401() ->
 
 test_metrics_auth_200() ->
     Request = {metrics_uri(), [metrics_auth_header()]},
+    {ok, {{_, 200, _}, _, _}} = httpc:request(get, Request, [], []).
+
+health_uri() -> "http://0:47811/health-check".
+
+test_health_check_200() ->
+    Request = {health_uri(), []},
     {ok, {{_, 200, _}, _, _}} = httpc:request(get, Request, [], []).
 
 uri() -> "http://0:47811/v1/batch".


### PR DESCRIPTION
Sometimes it is good to have an endpoint available which will return HTTP 200 when the service is up and running, for example for load balancers or caches. Rib currently only offers HTTP 200 when POSTing, which not every software supports when sending health-check pings or when retrieving metrics, but those are behind HTTP Basic auth which, again, not every software supports.

This adds an endpoint which returns HTTP 200 on GET requests without any fuss. It even returns a trailing newline so curl users don't get a weird prompt on bash.

(For a similar reason, it does not return 204 no content because who knows whether software supports this, so it writes some bytes as a response)