### PR TITLE
Add configurable HTTP timeout.

### DIFF
--- a/src/rib.app.src
+++ b/src/rib.app.src
@@ -11,6 +11,7 @@
                  ]},
   {mod, { rib_app, []}},
   {env, [{backend, "https://api.github.com"},
+         {timeout, 10},
          {metrics_user, <<"foo">>},
          {metrics_pass, <<"bar">>},
          {port, 3000}]}

--- a/src/rib_conn_killer.erl
+++ b/src/rib_conn_killer.erl
@@ -12,9 +12,12 @@ start_link() ->
 
 go() ->
     {ok, Base} = application:get_env(rib, backend),
+    TimeoutSecs = application:get_env(rib, timeout, 10),
+
     Url = Base ++ "/",
     Headers = [{"connection", "close"}],
-    {ok, _} = httpc:request(get, {Url, Headers}, [], [], rib),
+    Opts = [{timeout, timer:seconds(TimeoutSecs)}],
+    {ok, _} = httpc:request(get, {Url, Headers}, Opts, [], rib),
     receive
     after
         30000 -> go()

--- a/src/rib_fetch.erl
+++ b/src/rib_fetch.erl
@@ -47,14 +47,19 @@ maybe_distinct(_Req, Paths) ->
   Paths.
 
 fetch_one(RawPath, Req) ->
+    TimeoutSecs = application:get_env(rib, timeout, 10),
     #{method := Method, name := Name} = Req,
     {Url, Path} = resolve_path(RawPath),
-    RequestArgs = [Method, case Method of
-                               get -> {Url, headers()};
-                               head -> {Url, headers()};
-                               options -> {Url, headers()};
-                               post -> {Url, headers(), "", <<>>}
-                           end, [], [], rib],
+    RequestArgs = [Method,
+                   case Method of
+                     get -> {Url, headers()};
+                     head -> {Url, headers()};
+                     options -> {Url, headers()};
+                     post -> {Url, headers(), "", <<>>}
+                   end,
+                   [{timeout, timer:seconds(TimeoutSecs)}],
+                   [],
+                   rib],
     {Taken, {ok, Resp}} = timer:tc(httpc, request, RequestArgs),
     Body = try
                rib_slurp:slurp_response(Resp)


### PR DESCRIPTION
This PR adds a configurable timeout to single HTTP requests, as well as the connection killer. It defaults to 10s.