### PR TITLE
Do not use Supervisor for Test Backend Startup/Shutdown

### DIFF
--- a/test/rib_backend_callback.erl
+++ b/test/rib_backend_callback.erl
@@ -1,0 +1,14 @@
+-module(rib_backend_callback).
+-export([handle/2, handle_event/3]).
+-behaviour(elli_handler).
+
+%% ===================================================================
+%% Test Backend for Integration Tests
+%% ===================================================================
+handle(_Req, _Args) ->
+    {200,
+     [{"content-type", "application/json"}],
+     jiffy:encode(#{foo => bar})}.
+
+handle_event(_Event, _Data, _Args) ->
+    ok.


### PR DESCRIPTION
This is a small simplification of the testing logic, removing the supervisor code. Additionally, the shutdown logic has been adjusted a bit, based on [this SO answer](http://stackoverflow.com/a/21138557/1916789).

No idea if this addresses #13 in any way. 3x6 builds have succeeded but that might not mean anything (which the build triggered by this PR will probably prove).